### PR TITLE
Remove token limits in python app

### DIFF
--- a/t (1).py
+++ b/t (1).py
@@ -58,8 +58,7 @@ class GPTOSSChatbot:
             response = self.session.post(
                 f"{self.base_url}/chatkit",
                 json=payload,
-                stream=True,
-                timeout=30
+                stream=True
             )
             response.raise_for_status()
             
@@ -101,8 +100,8 @@ class GPTOSSChatbot:
                         entry = update.get('entry', {})
                         if entry.get('type') == 'thought':
                             content = entry.get('content', '')
-                            if content and len(content) > 50:  # Only show substantial reasoning
-                                print(f"\n💭 Reasoning: {content[:100]}..." if len(content) > 100 else f"\n💭 Reasoning: {content}")
+                            if content:  # Show all reasoning content without limits
+                                print(f"\n💭 Reasoning: {content}")
                                 reasoning_shown = True
                     
                     # Handle text deltas (streaming response)


### PR DESCRIPTION
Remove API timeout and reasoning content display limits to allow for unlimited input/output.

---
<a href="https://cursor.com/background-agent?bcId=bc-59647be8-1724-4aa2-a25f-6bf1dec9ff8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59647be8-1724-4aa2-a25f-6bf1dec9ff8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

